### PR TITLE
Lazy Creation of Google Proxy Groups

### DIFF
--- a/cirrus/google_cloud/manager.py
+++ b/cirrus/google_cloud/manager.py
@@ -162,7 +162,7 @@ class GoogleCloudManager(CloudManager):
                     string
                 ]
             }
-                    
+
         """
         group_name = _get_proxy_group_name_for_user(user_id, username)
         # Create group

--- a/cirrus/google_cloud/manager.py
+++ b/cirrus/google_cloud/manager.py
@@ -134,64 +134,41 @@ class GoogleCloudManager(CloudManager):
 
     def create_proxy_group_for_user(self, user_id, username):
         """
-        Creates a proxy group for the given user, creates a service account
-        for the user, and adds the service account to the group.
+        Creates a proxy group for the given user, does NOT create a 
+        service account for the proxy group
 
         Args:
             user_id (int): User's Unique ID
             username (str): User's name
 
         Returns:
-            dict: JSON responses from API calls, which should contain the new group
+            JSON responses from API call, which should contain the new group
             `Google API Reference <https://cloud.google.com/iam/reference/rest/v1/Policy>`_
-            and successfully created service account
-            `Google API Reference <https://cloud.google.com/iam/reference/rest/v1/projects.serviceAccounts#ServiceAccount>`_
 
             .. code-block:: python
-
-                {
-                    "group": {
-                        "kind": "admin#directory#group",
-                        "id": string,
-                        "etag": etag,
-                        "email": string,
-                        "name": string,
-                        "directMembersCount": long,
-                        "description": string,
-                        "adminCreated": boolean,
-                        "aliases": [
-                            string
-                        ],
-                        "nonEditableAliases": [
-                            string
-                        ]
-                    }
-                    "primary_service_account": {
-                        "name": string,
-                        "projectId": string,
-                        "uniqueId": string,
-                        "email": string,
-                        "displayName": string,
-                        "etag": string,
-                        "oauth2ClientId": string,
-                    }
-                }
+            
+            new_group_response = {
+                "kind": "admin#directory#group",
+                "id": string,
+                "etag": etag,
+                "email": string,
+                "name": string,
+                "directMembersCount": long,
+                "description": string,
+                "adminCreated": boolean,
+                "aliases": [
+                    string
+                ],
+                "nonEditableAliases": [
+                    string
+                ]
+            }
+                    
         """
         group_name = _get_proxy_group_name_for_user(user_id, username)
-        service_account_id = get_valid_service_account_id_for_user(
-            user_id, username
-        )
-
-        # Create group and service account, then add service account to group
+        # Create group
         new_group_response = self.create_group(name=group_name)
-        new_group_id = new_group_response["email"]
-        service_account_response = self.create_service_account_for_proxy_group(
-            new_group_id, account_id=service_account_id)
-
-        return {
-            "group": new_group_response,
-            "primary_service_account": service_account_response
-        }
+        return new_group_response
 
     def get_access_key(self, account):
         """

--- a/cirrus/google_cloud/manager.py
+++ b/cirrus/google_cloud/manager.py
@@ -134,8 +134,7 @@ class GoogleCloudManager(CloudManager):
 
     def create_proxy_group_for_user(self, user_id, username):
         """
-        Creates a proxy group for the given user, does NOT create a 
-        service account for the proxy group
+        Creates a proxy group for the given user
 
         Args:
             user_id (int): User's Unique ID
@@ -146,7 +145,7 @@ class GoogleCloudManager(CloudManager):
             `Google API Reference <https://cloud.google.com/iam/reference/rest/v1/Policy>`_
 
             .. code-block:: python
-            
+
             new_group_response = {
                 "kind": "admin#directory#group",
                 "id": string,

--- a/cirrus/google_cloud/manager.py
+++ b/cirrus/google_cloud/manager.py
@@ -1029,6 +1029,9 @@ class GoogleCloudManager(CloudManager):
                 self._admin_service.members().delete(
                     groupKey=group_id, memberKey=member_email).execute()
             )
+            # Google's api returns empty string on success
+            if response == '':
+                response = {}
         except HttpError as err:
             if err.resp.status == 404:
                 # not found, member isn't in group. This is fine


### PR DESCRIPTION
* GoogleCloudManager was creating service accounts when proxy groups were created. Previously, fence was modified to create service accounts when needed, so this no longer needs to be done. Removed code that added service account to new proxy group.