### PR TITLE
fix(error): inherit Exception

### DIFF
--- a/cirrus/errors.py
+++ b/cirrus/errors.py
@@ -1,4 +1,4 @@
-class CirrusError(BaseException):
+class CirrusError(Exception):
     def __init__(self, message="There was an error within the cirrus library.", *args):
         super(CirrusError, self).__init__(message)
 

--- a/test/test_google_cloud_manage.py
+++ b/test/test_google_cloud_manage.py
@@ -1279,8 +1279,9 @@ def test_handled_exception_no_retry(test_cloud_manager):
             test_cloud_manager.add_member_to_group(
                 member_email="test-email@test-domain.com", group_id="abc"
             )
-        assert logger_warn.call_count <= BACKOFF_SETTINGS["max_tries"] - 1
-        assert logger_error.call_count <= 1
+        assert logger_warn.call_count == 0
+        # two google api calls: get_group_members and add_member_to_group
+        assert logger_error.call_count >= 1
 
 
 def test_handled_exception_403_no_retry(test_cloud_manager):


### PR DESCRIPTION
BaseException not meant to be directly inherited by user-defined classes 

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features


### Breaking Changes


### Bug Fixes
- Cirrus exception inherits from Exception instead of BaseException

### Improvements


### Dependency updates


### Deployment changes

