### PR TITLE
[PXP-2454] fix(backoff): Backoff retry on rate/quota 403s (read error reason to determine)

### DIFF
--- a/cirrus/google_cloud/manager.py
+++ b/cirrus/google_cloud/manager.py
@@ -123,7 +123,7 @@ def _is_handled_exception(e):
 
     return isinstance(e, CirrusError)
     #"""
-    #"""
+    # """
     if isinstance(e, HttpError):
         if e.resp.status == 403:
             # True unless it's a rate limit error.
@@ -137,21 +137,21 @@ def _is_handled_exception(e):
                 "concurrentLimitExceeded",
                 "limitExceeded",
                 "rateLimitExceeded",
-                "userRateLimitExceeded"
+                "userRateLimitExceeded",
             ]
             # Valid rate limit reasons from DIRECTORY API
             # developers.google.com/admin-sdk/directory/v1/limits
-            directory_rlreasons = [
-                "userRateLimitExceeded",
-                "quotaExceeded"
-            ]
+            directory_rlreasons = ["userRateLimitExceeded", "quotaExceeded"]
             # Valid rate limit reasons from IAM API
             # IAM API doesn't seem to return rate-limit 403s.
-            return e.resp.reason not in resource_rlreasons and e.resp.reason not in directory_rlreasons
+            return (
+                e.resp.reason not in resource_rlreasons
+                and e.resp.reason not in directory_rlreasons
+            )
         return False
 
     return isinstance(e, CirrusError)
-    #"""
+    # """
 
 
 # Default settings to control usage of backoff library.

--- a/cirrus/google_cloud/manager.py
+++ b/cirrus/google_cloud/manager.py
@@ -115,12 +115,43 @@ def log_backoff_giveup(details):
 
 
 def _is_handled_exception(e):
+    """
     if isinstance(e, HttpError):
         if e.resp.status == 403:
             return True
         return False
 
     return isinstance(e, CirrusError)
+    #"""
+    #"""
+    if isinstance(e, HttpError):
+        if e.resp.status == 403:
+            # True unless it's a rate limit error.
+            # Note: There is overlap in the reason codes for these APIs
+            # which is not ideal. e.g. userRateLimitExceeded is in both.
+            # Fortunately both cases warrant retrying.
+            # Valid rate limit reasons from CLOUD RESOURCE MANAGER API
+            # cloud.google.com/resource-manager/docs/core_errors#FORBIDDEN
+            # Many limit errors listed; only a few warrant retry.
+            resource_rlreasons = [
+                "concurrentLimitExceeded",
+                "limitExceeded",
+                "rateLimitExceeded",
+                "userRateLimitExceeded"
+            ]
+            # Valid rate limit reasons from DIRECTORY API
+            # developers.google.com/admin-sdk/directory/v1/limits
+            directory_rlreasons = [
+                "userRateLimitExceeded",
+                "quotaExceeded"
+            ]
+            # Valid rate limit reasons from IAM API
+            # IAM API doesn't seem to return rate-limit 403s.
+            return e.resp.reason not in resource_rlreasons and e.resp.reason not in directory_rlreasons
+        return False
+
+    return isinstance(e, CirrusError)
+    #"""
 
 
 # Default settings to control usage of backoff library.

--- a/cirrus/google_cloud/manager.py
+++ b/cirrus/google_cloud/manager.py
@@ -114,16 +114,13 @@ def log_backoff_giveup(details):
     )
 
 
-def _is_handled_exception(e):
+def exception_do_not_retry(e):
     """
-    if isinstance(e, HttpError):
-        if e.resp.status == 403:
-            return True
-        return False
-
-    return isinstance(e, CirrusError)
-    #"""
-    # """
+    True if we should not retry.
+    - We should not retry for errors that we raise (CirrusErrors)
+    - We should not retry for Google errors that are not temporary
+      and not recoverable by retry
+    """
     if isinstance(e, HttpError):
         if e.resp.status == 403:
             # True unless it's a rate limit error.
@@ -151,7 +148,6 @@ def _is_handled_exception(e):
         return False
 
     return isinstance(e, CirrusError)
-    # """
 
 
 # Default settings to control usage of backoff library.
@@ -159,7 +155,7 @@ BACKOFF_SETTINGS = {
     "on_backoff": log_backoff_retry,
     "on_giveup": log_backoff_giveup,
     "max_tries": 5,
-    "giveup": _is_handled_exception,
+    "giveup": exception_do_not_retry,
 }
 
 

--- a/test/test_google_cloud_manage.py
+++ b/test/test_google_cloud_manage.py
@@ -1428,7 +1428,9 @@ def test_handled_exception_403_no_retry(test_cloud_manager):
     """
     from cirrus.google_cloud.manager import BACKOFF_SETTINGS
 
-    response = httplib2.Response({"status": "403", "reason": "forbidden", "content-type": "application/json"})
+    response = httplib2.Response(
+        {"status": "403", "reason": "forbidden", "content-type": "application/json"}
+    )
     http_error = HttpError(resp=response, content="")
     mock_config = {"get.side_effect": http_error}
     test_cloud_manager._authed_session.configure_mock(**mock_config)
@@ -1458,7 +1460,9 @@ def test_unhandled_exception_403_ratelimit_retry(test_cloud_manager):
     """
     from cirrus.google_cloud.manager import BACKOFF_SETTINGS
 
-    response = httplib2.Response({"status": "403", "reason": "quotaExceeded", "content-type": "application/json"})
+    response = httplib2.Response(
+        {"status": "403", "reason": "quotaExceeded", "content-type": "application/json"}
+    )
     http_error = HttpError(resp=response, content="")
     mock_config = {"get.side_effect": http_error}
     test_cloud_manager._authed_session.configure_mock(**mock_config)

--- a/test/test_google_cloud_manage.py
+++ b/test/test_google_cloud_manage.py
@@ -1480,8 +1480,6 @@ def test_unhandled_exception_403_ratelimit_retry(test_cloud_manager):
             test_cloud_manager.get_service_account_type(
                 account="test-email@test-domain.com"
             )
-        # TODO: Why is this part >= in the other ones?? Are we just not sure? =.=
-        # TODO: I think it should just be ==
         assert logger_warn.call_count == BACKOFF_SETTINGS["max_tries"] - 1
         assert logger_error.call_count == 1
 

--- a/test/test_google_cloud_manage.py
+++ b/test/test_google_cloud_manage.py
@@ -1422,12 +1422,13 @@ def test_handled_exception_no_retry(test_cloud_manager):
 
 def test_handled_exception_403_no_retry(test_cloud_manager):
     """
-    Test that when a handled exception is raised (e.g. a cirrus error), we
-    do NOT retry the Google API call
+    Test that when a handled exception is raised
+    (e.g. a 403 HttpError unrelated to rate limiting),
+    we do NOT retry the Google API call
     """
     from cirrus.google_cloud.manager import BACKOFF_SETTINGS
 
-    response = httplib2.Response({"status": "403", "content-type": "application/json"})
+    response = httplib2.Response({"status": "403", "reason": "forbidden", "content-type": "application/json"})
     http_error = HttpError(resp=response, content="")
     mock_config = {"get.side_effect": http_error}
     test_cloud_manager._authed_session.configure_mock(**mock_config)
@@ -1446,6 +1447,38 @@ def test_handled_exception_403_no_retry(test_cloud_manager):
                 account="test-email@test-domain.com"
             )
         assert logger_warn.call_count == 0
+        assert logger_error.call_count == 1
+
+
+def test_unhandled_exception_403_ratelimit_retry(test_cloud_manager):
+    """
+    Test that when an unhandled exception is raised
+    (in particular a 403 HttpError that is related to rate limiting),
+    we retry the Google API call
+    """
+    from cirrus.google_cloud.manager import BACKOFF_SETTINGS
+
+    response = httplib2.Response({"status": "403", "reason": "quotaExceeded", "content-type": "application/json"})
+    http_error = HttpError(resp=response, content="")
+    mock_config = {"get.side_effect": http_error}
+    test_cloud_manager._authed_session.configure_mock(**mock_config)
+    warn = cirrus.google_cloud.manager.logger.warn
+    error = cirrus.google_cloud.manager.logger.error
+    with mock.patch(
+        "cirrus.google_cloud.manager.logger.warn"
+    ) as logger_warn, mock.patch(
+        "cirrus.google_cloud.manager.logger.error"
+    ) as logger_error:
+        # keep the side effect to actually put logs, so you can see the format with `-s`
+        logger_warn.side_effect = warn
+        logger_error.side_effect = error
+        with pytest.raises(HttpError):
+            test_cloud_manager.get_service_account_type(
+                account="test-email@test-domain.com"
+            )
+        # TODO: Why is this part >= in the other ones?? Are we just not sure? =.=
+        # TODO: I think it should just be ==
+        assert logger_warn.call_count == BACKOFF_SETTINGS["max_tries"] - 1
         assert logger_error.call_count == 1
 
 


### PR DESCRIPTION
### New Features

### Breaking Changes

### Bug Fixes
Make cirrus use backoff retry logic on 403s only if they mention issues with rate or quota

### Improvements

### Dependency updates

### Deployment changes

