### PR TITLE
Fix/response

### DIFF
--- a/cirrus/google_cloud/manager.py
+++ b/cirrus/google_cloud/manager.py
@@ -134,7 +134,7 @@ def get_reason(http_error):
         reason = ""
     return reason
 
-  
+
 def exception_do_not_retry(e):
     """
     True if we should not retry.
@@ -165,8 +165,7 @@ def exception_do_not_retry(e):
             # Valid rate limit reasons from IAM API
             # IAM API doesn't seem to return rate-limit 403s.
             return (
-                reason not in resource_rlreasons
-                and reason not in directory_rlreasons
+                reason not in resource_rlreasons and reason not in directory_rlreasons
             )
         return False
 

--- a/cirrus/google_cloud/manager.py
+++ b/cirrus/google_cloud/manager.py
@@ -1389,7 +1389,8 @@ class GoogleCloudManager(CloudManager):
             `Google API Reference <https://developers.google.com/admin-sdk/directory/v1/reference/groups/delete>`_
         """
         try:
-            return self._admin_service.groups().delete(groupKey=group_id).execute()
+            r = self._admin_service.groups().delete(groupKey=group_id).execute()
+            return {} if r == "" else r
         except GoogleHttpError as err:
             if err.resp.status == 404:
                 # not found, group doesn't exist. This is fine

--- a/cirrus/google_cloud/manager.py
+++ b/cirrus/google_cloud/manager.py
@@ -1389,6 +1389,7 @@ class GoogleCloudManager(CloudManager):
         """
         try:
             r = self._admin_service.groups().delete(groupKey=group_id).execute()
+            # Directory API's notion of empty response body is "", differing from other APIs' {}
             return {} if r == "" else r
         except GoogleHttpError as err:
             if err.resp.status == 404:

--- a/cirrus/google_cloud/manager.py
+++ b/cirrus/google_cloud/manager.py
@@ -1101,8 +1101,8 @@ class GoogleCloudManager(CloudManager):
         Return a list of all groups in the domain
 
         Returns:
-            dict: JSON response from API call, which should contain a list
-                  of groups
+            list(dict): groups field of JSON response from API call,
+            which should contain a list of groups
             `Google API Reference <https://developers.google.com/admin-sdk/directory/v1/reference/groups/list>`_
 
             .. code-block:: python

--- a/test/test_google_cloud_manage.py
+++ b/test/test_google_cloud_manage.py
@@ -1030,10 +1030,7 @@ def test_get_all_groups_pagination(test_cloud_manager):
     assert kwargs["pageToken"] == next_page_token
 
 
-@pytest.mark.parametrize(
-    "google_return_value",
-    [ {}, "" ]
-)
+@pytest.mark.parametrize("google_return_value", [{}, ""])
 def test_delete_group(test_cloud_manager, google_return_value):
     """
     Test that deleting a group return the ID from the API response and that
@@ -1041,7 +1038,9 @@ def test_delete_group(test_cloud_manager, google_return_value):
     """
     # Setup #
     group_id = "123"
-    mock_config = {"groups.return_value.delete.return_value.execute.return_value": google_return_value}
+    mock_config = {
+        "groups.return_value.delete.return_value.execute.return_value": google_return_value
+    }
     test_cloud_manager._admin_service.configure_mock(**mock_config)
 
     # Call #

--- a/test/test_google_cloud_manage.py
+++ b/test/test_google_cloud_manage.py
@@ -1030,14 +1030,18 @@ def test_get_all_groups_pagination(test_cloud_manager):
     assert kwargs["pageToken"] == next_page_token
 
 
-def test_delete_group(test_cloud_manager):
+@pytest.mark.parametrize(
+    "google_return_value",
+    [ {}, "" ]
+)
+def test_delete_group(test_cloud_manager, google_return_value):
     """
     Test that deleting a group return the ID from the API response and that
     the API is called with the correct values
     """
     # Setup #
     group_id = "123"
-    mock_config = {"groups.return_value.delete.return_value.execute.return_value": {}}
+    mock_config = {"groups.return_value.delete.return_value.execute.return_value": google_return_value}
     test_cloud_manager._admin_service.configure_mock(**mock_config)
 
     # Call #


### PR DESCRIPTION
https://developers.google.com/admin-sdk/directory/v1/reference/groups/delete 
This endpoint returns "" not {} 

### New Features


### Breaking Changes


### Bug Fixes
delete_group in Google Cloud Manager now expects "" not {} as success response from Google Directory API's Groups: delete endpoint


### Improvements


### Dependency updates


### Deployment changes

