### PR TITLE
fix(bucket-update): append to members for roles, don't delete old access

### DIFF
--- a/cirrus/google_cloud/manager.py
+++ b/cirrus/google_cloud/manager.py
@@ -630,7 +630,9 @@ class GoogleCloudManager(CloudManager):
                 )
 
         for role in roles:
-            policy[str(role)] = [str(member)]
+            members = policy.get(str(role), set()) or set()
+            members.add(str(member))
+            policy[str(role)] = members
 
         bucket.set_iam_policy(policy)
 


### PR DESCRIPTION

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
- when updating a bucket, don't replace access, append to it

### Dependency updates


### Deployment changes

