### PR TITLE
fix(delete-key): ignore 404

### DIFF
--- a/cirrus/google_cloud/manager.py
+++ b/cirrus/google_cloud/manager.py
@@ -903,7 +903,14 @@ class GoogleCloudManager(CloudManager):
             GOOGLE_IAM_API_URL,
         )
 
-        response = self._authed_request("DELETE", api_url)
+        try:
+            response = self._authed_request("DELETE", api_url)
+        except GoogleHttpError as err:
+            if err.resp.status == 404:
+                # key doesn't exist so return "success"
+                return {}
+
+            raise
 
         return response.json()
 


### PR DESCRIPTION
### Bug Fixes
- no error should be thrown when attempting to delete a SA key that does not exist in google
