### PR TITLE
Move util fns from manager to utils; remove leading underscores

### DIFF
--- a/cirrus/google_cloud/utils.py
+++ b/cirrus/google_cloud/utils.py
@@ -160,7 +160,7 @@ def get_signed_url(
         str: Completed signed URL
     """
     path_to_resource = path_to_resource.strip("/")
-    string_to_sign = get_string_to_sign(
+    string_to_sign = _get_string_to_sign(
         path_to_resource, http_verb, expires, extension_headers, content_type, md5_value
     )
 
@@ -191,7 +191,7 @@ def get_signed_url(
     return final_url
 
 
-def get_string_to_sign(
+def _get_string_to_sign(
     path_to_resource,
     http_verb,
     expires,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,5 @@
 import time
+
 # Python 2 and 3 compatible
 try:
     from unittest.mock import MagicMock
@@ -10,7 +11,6 @@ except ImportError:
 import pytest
 
 from cirrus import GoogleCloudManager
-from cirrus.google_cloud.manager import _get_proxy_group_name_for_user
 from cirrus.google_cloud.utils import get_valid_service_account_id_for_user
 
 

--- a/test/test_google_cloud_manage.py
+++ b/test/test_google_cloud_manage.py
@@ -23,11 +23,11 @@ from cirrus.google_cloud import (
     COMPUTE_ENGINE_API_SERVICE_ACCOUNT,
     USER_MANAGED_SERVICE_ACCOUNT,
 )
-from cirrus.google_cloud.manager import (
-    _get_proxy_group_name_for_user,
-    _get_prefix_from_proxy_group,
-    _get_user_name_from_proxy_group,
-    _get_user_id_from_proxy_group,
+from cirrus.google_cloud.utils import (
+    get_proxy_group_name_for_user,
+    get_prefix_from_proxy_group,
+    get_user_name_from_proxy_group,
+    get_user_id_from_proxy_group,
     get_valid_service_account_id_for_user,
 )
 import cirrus.google_cloud.manager
@@ -61,7 +61,7 @@ def test_get_proxy_group_name_for_user():
     """
     user_id = "12345678912345678901234567890"
     username = ".a-bcd..efg@hijkl<@$*)%amn.net"
-    valid_name = _get_proxy_group_name_for_user(user_id, username)
+    valid_name = get_proxy_group_name_for_user(user_id, username)
 
     assert valid_name == "a_bcd.efghijklamn.net-12345678912345678901234567890"
 
@@ -77,7 +77,7 @@ def test_get_proxy_group_name_for_user_with_prefix():
     user_id = "12345678912345678901234567890"
     username = ".a-bcd..efg@hijkl<@$*)%amn.net"
     prefix = "Some App Name"
-    valid_name = _get_proxy_group_name_for_user(user_id, username, prefix=prefix)
+    valid_name = get_proxy_group_name_for_user(user_id, username, prefix=prefix)
 
     assert valid_name == "Some_App_Name-a_bcd.efghijklam-12345678912345678901234567890"
 
@@ -93,16 +93,16 @@ def test_get_proxy_group_name_for_user_prefix_with_dashes():
     user_id = "12345678912345678901234567890"
     username = ".a-bcd..efg@hijkl<@$*)%amn.net"
     prefix = "Some-App-Name"
-    valid_name = _get_proxy_group_name_for_user(user_id, username, prefix=prefix)
+    valid_name = get_proxy_group_name_for_user(user_id, username, prefix=prefix)
 
     assert valid_name == "Some_App_Name-a_bcd.efghijklam-12345678912345678901234567890"
 
 
 def test_get_items_from_proxy_group_name():
     valid_name = "Some_App_Name-a_bcd.efghijklam-12345678912345678901234567890"
-    prefix = _get_prefix_from_proxy_group(valid_name)
-    username = _get_user_name_from_proxy_group(valid_name)
-    user_id = _get_user_id_from_proxy_group(valid_name)
+    prefix = get_prefix_from_proxy_group(valid_name)
+    username = get_user_name_from_proxy_group(valid_name)
+    user_id = get_user_id_from_proxy_group(valid_name)
 
     assert prefix == "Some_App_Name"
     assert username == "a_bcd.efghijklam"
@@ -111,9 +111,9 @@ def test_get_items_from_proxy_group_name():
 
 def test_get_items_from_proxy_group_name_no_prefix():
     valid_name = "a_bcd.efghijklam-12345678912345678901234567890"
-    prefix = _get_prefix_from_proxy_group(valid_name)
-    username = _get_user_name_from_proxy_group(valid_name)
-    user_id = _get_user_id_from_proxy_group(valid_name)
+    prefix = get_prefix_from_proxy_group(valid_name)
+    username = get_user_name_from_proxy_group(valid_name)
+    user_id = get_user_id_from_proxy_group(valid_name)
 
     assert prefix == ""
     assert username == "a_bcd.efghijklam"
@@ -869,7 +869,7 @@ def test_get_primary_service_account(test_cloud_manager):
         + test_domain
     )
 
-    group_name = _get_proxy_group_name_for_user(new_member_1_id, new_member_1_username)
+    group_name = get_proxy_group_name_for_user(new_member_1_id, new_member_1_username)
     group_email = group_name + "@" + test_domain
     mock_get_group(test_cloud_manager, group_name, group_email)
 
@@ -910,7 +910,7 @@ def test_get_service_account_from_group_mult_accounts(test_cloud_manager):
         + test_domain
     )
 
-    group_name = _get_proxy_group_name_for_user(new_member_1_id, new_member_1_username)
+    group_name = get_proxy_group_name_for_user(new_member_1_id, new_member_1_username)
     group_email = group_name + "@" + test_domain
     mock_get_group(test_cloud_manager, group_name, group_email)
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -9,7 +9,7 @@ except ImportError:
     from mock import patch
 
 from cirrus.google_cloud.utils import (
-    get_string_to_sign,
+    _get_string_to_sign,
     get_valid_service_account_id_for_client,
     get_valid_service_account_id_for_user,
 )
@@ -69,7 +69,7 @@ def test_get_string_to_sign():
     ext_headers = ["x-goog-encryption-algorithm:AES256", "x-goog-meta-foo:bar,baz"]
     resource_path = "/bucket/objectname"
 
-    result = get_string_to_sign(
+    result = _get_string_to_sign(
         path_to_resource=resource_path,
         http_verb=http_verb,
         expires=expires,
@@ -94,7 +94,7 @@ def test_get_string_to_sign_no_optional_params():
     expires = "1388534400"
     resource_path = "/bucket/objectname"
 
-    result = get_string_to_sign(
+    result = _get_string_to_sign(
         path_to_resource=resource_path, http_verb=http_verb, expires=expires
     )
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -8,8 +8,8 @@ except ImportError:
     from mock import MagicMock
     from mock import patch
 
-from cirrus.google_cloud.utils import _get_string_to_sign
 from cirrus.google_cloud.utils import (
+    get_string_to_sign,
     get_valid_service_account_id_for_client,
     get_valid_service_account_id_for_user,
 )
@@ -69,7 +69,7 @@ def test_get_string_to_sign():
     ext_headers = ["x-goog-encryption-algorithm:AES256", "x-goog-meta-foo:bar,baz"]
     resource_path = "/bucket/objectname"
 
-    result = _get_string_to_sign(
+    result = get_string_to_sign(
         path_to_resource=resource_path,
         http_verb=http_verb,
         expires=expires,
@@ -94,7 +94,7 @@ def test_get_string_to_sign_no_optional_params():
     expires = "1388534400"
     resource_path = "/bucket/objectname"
 
-    result = _get_string_to_sign(
+    result = get_string_to_sign(
         path_to_resource=resource_path, http_verb=http_verb, expires=expires
     )
 


### PR DESCRIPTION
Moves some util functions from google_cloud/manager.py to google_cloud/utils.py. Removes leading underscores from their names. 

### Breaking Changes
- Some util functions have been renamed (leading underscores removed) and pushed to utils file

