### PR TITLE
chore(sa-types): simplify type to just be the domain

### DIFF
--- a/cirrus/google_cloud/__init__.py
+++ b/cirrus/google_cloud/__init__.py
@@ -1,9 +1,3 @@
-from .manager import (
-    GoogleCloudManager,
-    COMPUTE_ENGINE_DEFAULT_SERVICE_ACCOUNT,
-    GOOGLE_API_SERVICE_ACCOUNT,
-    COMPUTE_ENGINE_API_SERVICE_ACCOUNT,
-    USER_MANAGED_SERVICE_ACCOUNT,
-)
+from .manager import GoogleCloudManager
 from .iam import GooglePolicy, GooglePolicyBinding, GooglePolicyMember, GooglePolicyRole
 from .utils import get_valid_service_account_id_for_client

--- a/cirrus/google_cloud/manager.py
+++ b/cirrus/google_cloud/manager.py
@@ -64,23 +64,17 @@ GOOGLE_STORAGE_CLASSES = [
     "STANDARD",  # alias for MULTI_REGIONAL/REGIONAL, based on location
 ]
 
-APP_ENGINE_DEFAULT_SERVICE_ACCOUNT = "APP_ENGINE_DEFAULT_SERVICE_ACCOUNT"
-COMPUTE_ENGINE_DEFAULT_SERVICE_ACCOUNT = "COMPUTE_ENGINE_DEFAULT_SERVICE_ACCOUNT"
-GOOGLE_API_SERVICE_ACCOUNT = "GOOGLE_API_SERVICE_ACCOUNT"
-COMPUTE_ENGINE_API_SERVICE_ACCOUNT = "COMPUTE_ENGINE_API_SERVICE_ACCOUNT"
-USER_MANAGED_SERVICE_ACCOUNT = "USER_MANAGED_SERVICE_ACCOUNT"
-
 """
-This mapping is order-specific. More specific domains should appear
+This is order-specific. More specific domains should appear
 earlier in the list. For example, `compute-system.iam.gserviceaccount.com`
 should appear before `iam.gserviceaccount.com`
 """
-GOOGLE_SERVICE_ACCOUNT_DOMAIN_TYPE_MAPPING = [
-    ("appspot.gserviceaccount.com", APP_ENGINE_DEFAULT_SERVICE_ACCOUNT),
-    ("compute-system.iam.gserviceaccount.com", COMPUTE_ENGINE_DEFAULT_SERVICE_ACCOUNT),
-    ("cloudservices.gserviceaccount.com", GOOGLE_API_SERVICE_ACCOUNT),
-    ("developer.gserviceaccount.com", COMPUTE_ENGINE_API_SERVICE_ACCOUNT),
-    ("iam.gserviceaccount.com", USER_MANAGED_SERVICE_ACCOUNT),
+GOOGLE_SERVICE_ACCOUNT_DOMAIN_TYPES = [
+    "appspot.gserviceaccount.com",
+    "compute-system.iam.gserviceaccount.com",
+    "cloudservices.gserviceaccount.com",
+    "developer.gserviceaccount.com",
+    "iam.gserviceaccount.com",
 ]
 
 
@@ -691,9 +685,9 @@ class GoogleCloudManager(CloudManager):
         """
         service_account = self.get_service_account(account)
         email_domain = service_account.get("email", "").split("@")[-1]
-        for (domain, sa_type) in GOOGLE_SERVICE_ACCOUNT_DOMAIN_TYPE_MAPPING:
+        for domain in GOOGLE_SERVICE_ACCOUNT_DOMAIN_TYPES:
             if domain in email_domain:
-                return sa_type
+                return domain
 
         return None
 

--- a/test/test_google_cloud_manage.py
+++ b/test/test_google_cloud_manage.py
@@ -17,12 +17,6 @@ import pytest
 from requests import Response
 import httplib2
 
-from cirrus.google_cloud import (
-    COMPUTE_ENGINE_DEFAULT_SERVICE_ACCOUNT,
-    GOOGLE_API_SERVICE_ACCOUNT,
-    COMPUTE_ENGINE_API_SERVICE_ACCOUNT,
-    USER_MANAGED_SERVICE_ACCOUNT,
-)
 from cirrus.google_cloud.utils import (
     get_proxy_group_name_for_user,
     get_prefix_from_proxy_group,
@@ -1188,7 +1182,7 @@ def test_get_service_account_type_compute_engine_default(test_cloud_manager):
     )
     assert (
         test_cloud_manager.get_service_account_type(service_account)
-        == COMPUTE_ENGINE_DEFAULT_SERVICE_ACCOUNT
+        == "compute-system.iam.gserviceaccount.com"
     )
 
 
@@ -1200,7 +1194,7 @@ def test_get_service_account_type_google_api(test_cloud_manager):
     )
     assert (
         test_cloud_manager.get_service_account_type(service_account)
-        == GOOGLE_API_SERVICE_ACCOUNT
+        == "cloudservices.gserviceaccount.com"
     )
 
 
@@ -1212,7 +1206,7 @@ def test_get_service_account_type_compute_engine_api(test_cloud_manager):
     )
     assert (
         test_cloud_manager.get_service_account_type(service_account)
-        == COMPUTE_ENGINE_API_SERVICE_ACCOUNT
+        == "developer.gserviceaccount.com"
     )
 
 
@@ -1224,7 +1218,7 @@ def test_get_service_account_type_user_managed(test_cloud_manager):
     )
     assert (
         test_cloud_manager.get_service_account_type(service_account)
-        == USER_MANAGED_SERVICE_ACCOUNT
+        == "iam.gserviceaccount.com"
     )
 
 


### PR DESCRIPTION


### New Features


### Breaking Changes
- get service account type just returns the domain instead of the string of the name

### Bug Fixes


### Improvements
- simplify checking service account types

### Dependency updates


### Deployment changes

