### PR TITLE
fix(ancestry): traverse folders to get parent org

### DIFF
--- a/cirrus/google_cloud/manager.py
+++ b/cirrus/google_cloud/manager.py
@@ -468,20 +468,23 @@ class GoogleCloudManager(CloudManager):
 
     def get_project_organization(self):
         """
-        Return the organiation name for a project if it exists, otherwise
-        with return None.
+        Return the organization name for a project if it exists, otherwise
+        return None.
 
         Returns:
-            str: Organiztion name or None
+            str: Organization name or None
         """
-        info = self.get_project_info()
-
-        if "error" in info:
-            raise GoogleAPIError(str(info))
-
+        ancestors = self.get_project_ancestry()
         org = None
-        if info.get("parent", {}).get("type") == "organization":
-            org = info["parent"]["id"]
+        logger.debug("The ancestor chain is {}".format(ancestors))
+        if ancestors:
+            # Per google API, ancestors ordered from bottom of hierarchy to top
+            top_ancestor = ancestors.pop()
+            org = top_ancestor[1] if top_ancestor[0] == "organization" else None
+
+        logger.debug(
+            "Got parent organization {} for project {}".format(org, self.project_id)
+        )
 
         return org
 

--- a/test/test_google_cloud_manage.py
+++ b/test/test_google_cloud_manage.py
@@ -1309,6 +1309,41 @@ def test_has_no_parent_organization(test_cloud_manager):
     assert not test_cloud_manager.has_parent_organization()
 
 
+def test_get_parent_organization_with_org(test_cloud_manager):
+    """
+    Check that get_project_organization correctly returns parent organization
+    when the project is nested within folders
+    """
+    faked_response_body = {
+        "ancestor": [
+            {"resourceId": {"type": "project", "id": "1"}},
+            {"resourceId": {"type": "folder", "id": "2"}},
+            {"resourceId": {"type": "organization", "id": "3"}},
+        ]
+    }
+    test_cloud_manager._authed_session.post.return_value = _fake_response(
+        200, faked_response_body
+    )
+    assert test_cloud_manager.get_project_organization() == "3"
+
+
+def test_get_parent_organization_without_org(test_cloud_manager):
+    """
+    Check that get_project_organization correctly returns None
+    when the project has no parent organization
+    """
+    faked_response_body = {
+        "ancestor": [
+            {"resourceId": {"type": "project", "id": "1"}},
+            {"resourceId": {"type": "folder", "id": "2"}},
+        ]
+    }
+    test_cloud_manager._authed_session.post.return_value = _fake_response(
+        200, faked_response_body
+    )
+    assert test_cloud_manager.get_project_organization() == None
+
+
 def test_authed_session(test_cloud_manager):
     test_cloud_manager._authed_session = False
     with pytest.raises(GoogleAuthError):


### PR DESCRIPTION

### Bug Fixes
Correctly get project's parent organization when project is nested in folders.


